### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,8 @@ jobs:
     name: SonarQube
     runs-on: ubuntu-latest
     needs: [test, code-coverage]
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/10](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/10)

To fix the issue, we will add a `permissions` block to the `SonarQube` job to explicitly define the minimal permissions required. Based on the job's tasks, it primarily reads repository contents and uploads reports, so it only needs `contents: read`. This ensures the `GITHUB_TOKEN` has the least privilege necessary to complete the job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
