### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -253,6 +257,9 @@ jobs:
     name: Publish to crates.io
     needs: [create-release, build, verify-binaries]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     # Only publish on actual tag pushes, not workflow_dispatch
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/9](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for all jobs. Since the workflow involves creating releases, uploading assets, and publishing to crates.io, we will grant `contents: read` and `packages: write` permissions. Additionally, we will add job-specific `permissions` blocks where necessary to further restrict privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
