### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,8 @@ jobs:
   code-coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/8](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/8)

To fix the issue, we need to add an explicit `permissions` block to the `code-coverage` job in the workflow file. The permissions should be limited to the least privilege required for the job to function correctly. Based on the tasks performed by the `code-coverage` job (e.g., checking out code, generating coverage reports, and uploading artifacts), the `contents: read` permission is sufficient.

The `permissions` block should be added directly under the `runs-on` key for the `code-coverage` job. This ensures that the job does not inherit broader repository permissions and operates with minimal privileges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
