### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/6](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/6)

To fix the issue, add a `permissions` block to the `security-audit` job. Since the job only requires read access to the repository contents, the permissions should be set to `contents: read`. This change ensures that the job has the minimal permissions necessary to perform its tasks, reducing the risk of unintended write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
