### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
   build-cross-platform:
     name: Build on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/5](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the `build-cross-platform` job. This block will explicitly set the permissions to `contents: read`, which is the minimum required for the job to access the repository's contents. This change ensures that the job does not inherit unnecessary permissions from the repository's default settings.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
