### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/3](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `test` job. Based on the actions performed in the `test` job, it only needs read access to the repository contents. Therefore, we will set `contents: read` as the permission. This change will ensure that the `test` job adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
