### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,9 +1,13 @@
 name: Security Audit
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   schedule:
     # Run daily at 02:00 UTC
-    - cron: '0 2 * * *'
+   - cron: '0 2 * * *'
   push:
     branches: [ master, main ]
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/11](https://github.com/MathieuSoysal/CG-Bundler/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to the repository contents and write access to upload artifacts. We will set `contents: read` and `actions: write` as the permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
