### PR TITLE
Add Dependabot configuration for automated updates of Rust dependenci…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,69 @@
+# Dependabot configuration for CG-Bundler
+# Automatically updates Rust dependencies and GitHub Actions
+
+version: 2
+
+updates:
+  # Enable version updates for Cargo (Rust dependencies)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "MathieuSoysal"
+    assignees:
+      - "MathieuSoysal"
+    labels:
+      - "dependencies"
+      - "rust"
+      - "cargo"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    rebase-strategy: "auto"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      rust-major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "MathieuSoysal"
+    assignees:
+      - "MathieuSoysal"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "ci/cd"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    rebase-strategy: "auto"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"


### PR DESCRIPTION
This pull request introduces a Dependabot configuration file to automate dependency updates for Rust (`cargo`) and GitHub Actions. The configuration specifies update schedules, reviewer assignments, labels, and commit message conventions for each ecosystem.

### Dependabot configuration:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R69): Added configuration to enable weekly updates for Rust dependencies (`cargo`) on Mondays and GitHub Actions on Tuesdays, with specific reviewers, assignees, labels, and commit message prefixes. Includes grouping strategies for minor, patch, and major updates.